### PR TITLE
🔧 Support skipping the changelog via a commit trailer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,10 @@ This file provides guidance to AI coding agents when working with code in this r
 For contribution conventions — commit-message format, atomic commits, code layout, and
 more — follow the guidelines in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
+- **Changelog-skip trailer**: end a commit message with a `Changelog: skip` git trailer to
+  keep it out of the user-facing changelog (use for AI-workflow artifacts such as design docs
+  and implementation plans).
+
 ## Project Overview
 
 busd is a pure-Rust D-Bus bus (broker) implementation — the sibling daemon to the [zbus]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -79,11 +79,16 @@ commit_preprocessors = [
         if [ -n "$ref" ]; then printf "%s||%s\\n" "$title" "$ref"
         else printf "%s\\n" "$title"; fi
     '""" },
+    # Replace the message of commits carrying a "Changelog: skip" git trailer with a sentinel
+    # that the first commit parser below drops (e.g. AI-workflow design docs and plans).
+    { pattern = ".*", replace_command = "sh -c 'title=$(cat); if git log -1 --format=\"%(trailers:key=Changelog,valueonly)\" $COMMIT_SHA 2>/dev/null | grep -qix skip; then echo changelog-skip; else printf \"%s\\n\" \"$title\"; fi'" },
 ]
 
 # Categorize commits based on gimoji emojis.
 # See: https://zeenix.github.io/gimoji/
 commit_parsers = [
+    # Skip commits carrying a "Changelog: skip" trailer (see the preprocessor above).
+    { message = "^changelog-skip$", skip = true },
     # Skip merge commits, release commits, and empty commits (just emojis).
     { message = "^[Mm]erge", skip = true },
     { message = "^🔖", skip = true },


### PR DESCRIPTION
## What

Adds a `release-plz` preprocessor + parser pair that lets a commit opt out of the
generated `CHANGELOG.md` by ending its message with a `Changelog: skip` git trailer, and
documents the convention in `AGENTS.md`.

## Why

AI-workflow artifact commits (design docs, implementation plans) tend to pollute the
user-facing changelog with entries nobody wants to read at release time. release-plz's
commit parsers can't see git trailers directly, so a preprocessor rewrites the message of
any commit carrying the trailer to a sentinel that a parser entry then drops.

Usage: end a commit message with a `Changelog: skip` trailer (as this PR's second commit
does) to keep it out of the changelog.

## Verification

Ran the local scratch-commit matrix on this branch (`release-plz update`, inspecting the
resulting `git diff` of `CHANGELOG.md`, then reverting):

- `📝 Skip me A` (trailer `Changelog: skip`) — absent from the generated changelog. Pass.
- `📝 Keep me B` (`Changelog: skip mentioned as prose.` mid-body, not a trailer) — present
  as `- 📝 Keep me B.`. Pass.
- `📝 Keep me C` (no body) — present as `- 📝 Keep me C.`. Pass.

As a bonus this also confirmed dogfooding: the `📝 Document the changelog-skip trailer
convention` commit (which itself carries the trailer) is correctly absent from the
generated changelog, while the `🔧 Support skipping the changelog via a commit trailer`
commit (no trailer) correctly appears under "Changed".

Generated by Claude Fable 5 (claude-fable-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vw5uRE2AL6ddxgwqoPTxVr