### PR TITLE
🔧 Show changelog emojis on section headings only

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -35,16 +35,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 """
 
 # Changelog body template.
+# Each section heading carries the emoji of its category, so the leading emoji is stripped off
+# the entries rather than repeated on every line. One regex both recognises and removes it, so
+# the two can't disagree. It strips exactly one gimoji plus the whitespace after it, matching the
+# commit contract: a subject carries one prefix emoji, and everything after it — another emoji
+# included — is title text. So "✨ 🎉 Add foo" keeps its 🎉, and subjects with no separator after
+# the prefix ("⚰️a Drop …", "✨🏳️‍🌈 Rainbow") stay visibly malformed rather than being mangled.
+# The alternation is exactly the set of emoji this file routes to a group below; any other emoji
+# lands in the catch-all, where nothing is stripped. Keep the two in step when adding a parser.
+# The catch-all group is the exception: its heading emoji stands for no particular category, so
+# the entry emoji there is information rather than repetition and is kept. Those entries render
+# exactly as they did before this template existed.
+# `upper_first` applies only when nothing was stripped, and sees the subject untrimmed, exactly
+# as it did before. An emoji used to shield the rest of the subject from it; without that guard
+# it would rewrite "zbus_macros shouldn't …" into "Zbus_macros shouldn't …" and
+# "signature::Fields::len()" into "Signature::Fields::len()".
+# Group names are prefixed with an "<!-- NN -->" ordering comment, which `striptags` drops from
+# the rendered heading.
 # Issue refs are separated by "||" delimiter so we can insert period before them.
 body = """
 
 ## {{ version | trim_start_matches(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% for group, commits in commits | group_by(attribute="group") %}
-### {{ group | upper_first }}
+### {{ group | striptags | trim | upper_first }}
 {% for commit in commits %}\
 {% set first_line = commit.message | split(pat="\n") | first %}\
 {% set parts = first_line | split(pat="||") %}\
-- {{ parts | first | upper_first | trim | trim_end_matches(pat=".") }}\
+{% set subject = parts | first %}\
+{% if group is ending_with("Other") %}\
+{% set title = subject | upper_first %}\
+{% else %}\
+{% set title = subject | replace_regex(from="^\\s*(?:✨|🎉|🐛|🚑|🩹|🥅|⚡|📝|💡|♻|🎨|🚚|🔧|🏗|💄|💥|🔥|🗑|➕|➖|📌|⬆|⬇|🔒|✅|🧪|👷|💚)\\u{FE0F}?\\s+", to="") %}\
+{% if title == subject %}{% set title = title | upper_first %}{% endif %}\
+{% endif %}\
+- {{ title | trim | trim_end_matches(pat=".") }}\
 {% if commit.breaking %} (**BREAKING**){% endif %}.\
 {% if parts | length > 1 %} {{ parts | last }}{% endif %}
 {% endfor %}\
@@ -86,6 +110,8 @@ commit_preprocessors = [
 
 # Categorize commits based on gimoji emojis.
 # See: https://zeenix.github.io/gimoji/
+# The "<!-- NN -->" prefix on each group name fixes the order of the changelog sections
+# (the template strips it); the emoji right after it becomes the section heading emoji.
 commit_parsers = [
     # Skip commits carrying a "Changelog: skip" trailer (see the preprocessor above).
     { message = "^changelog-skip$", skip = true },
@@ -95,54 +121,53 @@ commit_parsers = [
     { message = "^[\\p{Emoji}\\p{Emoji_Presentation}\\p{Extended_Pictographic}]+$", skip = true },
 
     # Features.
-    { message = "^✨", group = "Added" },
-    { message = "^🎉", group = "Added" },
-    { message = "^👷", group = "Added" },
+    { message = "^✨", group = "<!-- 00 -->✨ Added" },
+    { message = "^🎉", group = "<!-- 00 -->✨ Added" },
 
     # Bug fixes.
-    { message = "^🐛", group = "Fixed" },
-    { message = "^🚑", group = "Fixed" },
-    { message = "^🩹", group = "Fixed" },
-    { message = "^🥅", group = "Fixed" },
+    { message = "^🐛", group = "<!-- 07 -->🐛 Fixed" },
+    { message = "^🚑", group = "<!-- 07 -->🐛 Fixed" },
+    { message = "^🩹", group = "<!-- 07 -->🐛 Fixed" },
+    { message = "^🥅", group = "<!-- 07 -->🐛 Fixed" },
 
     # Performance.
-    { message = "^⚡", group = "Performance" },
+    { message = "^⚡", group = "<!-- 09 -->⚡️ Performance" },
 
     # Documentation.
-    { message = "^📝", group = "Documentation" },
-    { message = "^💡", group = "Documentation" },
+    { message = "^📝", group = "<!-- 06 -->📝 Documentation" },
+    { message = "^💡", group = "<!-- 06 -->📝 Documentation" },
 
     # Refactoring/changes.
-    { message = "^♻️", group = "Changed" },
-    { message = "^🎨", group = "Changed" },
-    { message = "^🚚", group = "Changed" },
-    { message = "^🔧", group = "Changed" },
-    { message = "^🏗️", group = "Changed" },
-    { message = "^💄", group = "Changed" },
+    { message = "^♻️", group = "<!-- 03 -->♻️ Changed" },
+    { message = "^🎨", group = "<!-- 03 -->♻️ Changed" },
+    { message = "^🚚", group = "<!-- 03 -->♻️ Changed" },
+    { message = "^🔧", group = "<!-- 03 -->♻️ Changed" },
+    { message = "^🏗️", group = "<!-- 03 -->♻️ Changed" },
+    { message = "^💄", group = "<!-- 03 -->♻️ Changed" },
 
     # Breaking changes/removals.
-    { message = "^💥", group = "Breaking" },
-    { message = "^🔥", group = "Removed" },
-    { message = "^🗑️", group = "Deprecated" },
+    { message = "^💥", group = "<!-- 01 -->💥 Breaking" },
+    { message = "^🔥", group = "<!-- 10 -->🔥 Removed" },
+    { message = "^🗑️", group = "<!-- 05 -->🗑️ Deprecated" },
 
     # Dependencies.
-    { message = "^➕", group = "Dependencies" },
-    { message = "^➖", group = "Dependencies" },
-    { message = "^📌", group = "Dependencies" },
-    { message = "^⬆️", group = "Dependencies" },
-    { message = "^⬇️", group = "Dependencies" },
+    { message = "^➕", group = "<!-- 04 -->📦 Dependencies" },
+    { message = "^➖", group = "<!-- 04 -->📦 Dependencies" },
+    { message = "^📌", group = "<!-- 04 -->📦 Dependencies" },
+    { message = "^⬆️", group = "<!-- 04 -->📦 Dependencies" },
+    { message = "^⬇️", group = "<!-- 04 -->📦 Dependencies" },
 
     # Security.
-    { message = "^🔒", group = "Security" },
+    { message = "^🔒", group = "<!-- 11 -->🔒️ Security" },
 
     # Testing.
-    { message = "^✅", group = "Testing" },
-    { message = "^🧪", group = "Testing" },
+    { message = "^✅", group = "<!-- 12 -->✅ Testing" },
+    { message = "^🧪", group = "<!-- 12 -->✅ Testing" },
 
     # CI/Build.
-    { message = "^👷", group = "CI" },
-    { message = "^💚", group = "CI" },
+    { message = "^👷", group = "<!-- 02 -->👷 CI" },
+    { message = "^💚", group = "<!-- 02 -->👷 CI" },
 
     # Everything else.
-    { message = ".*", group = "Other" },
+    { message = ".*", group = "<!-- 08 -->⚙️ Other" },
 ]


### PR DESCRIPTION
Every changelog entry repeated the emoji from its commit message, directly under a section heading that already said the same thing in words:

```
### Added
- ✨ Implement unix:dir and unix:tmpdir for `--address`.
- ✨ Add --print-address.
```

This moves the emoji up to the heading, where it says something once:

```
### ✨ Added
- Implement unix:dir and unix:tmpdir for `--address`.
- Add --print-address.
```

## What changed

Only `release-plz.toml`:

- **Group names carry the emoji** — `group = "Added"` became `group = "<!-- 00 -->✨ Added"`, rendered through `striptags | trim | upper_first`. The `<!-- NN -->` prefix pins section order, reproducing the order that previously fell out of the alphabetical sort of the bare group names.
- **Entries drop their emoji prefix** — one `replace_regex` both recognises and removes it, so the two cannot disagree about where the prefix ends. It strips **exactly one** gimoji plus the whitespace after it, matching the commit contract: a subject carries one prefix emoji, and everything after it — another emoji included — is title text. The alternation lists exactly the emoji this file routes to a group; any other emoji can only reach the catch-all, where nothing is stripped.
- **The prefix must be followed by whitespace.** The one subject here without a separator (`♻️a Replace …`) stays visibly malformed rather than being mangled into `a Replace …`.
- **The catch-all group keeps its emoji.** `⚙️ Other` stands for no category, so an entry emoji there is information rather than repetition — 45 of this repo's 144 Other entries open with a distinct marker (`🔊`, `🚧`, `🚨`, `🚩`, `⏪️`, `⚰️`, `✏️`, `🍱`, `🏷️`, `💸`, `👽️`, `📦️` and more). Those entries render byte-identical to the pre-change output.
- **`upper_first` is guarded** — it applies only when nothing was stripped, and still sees the subject untrimmed. The emoji used to shield the rest of the subject from that filter; unguarded it rewrites `➖ rand now a dev-dependency` into `Rand now a dev-dependency.`
- **The dependency heading is 📦, not ⬆️.** That group also collects `➖`/`⬇️` — 5 entries here, including `➖ Drop now redundant nix dep` — which an upward arrow contradicts. Dependencies is the only group mixing opposite directions.
- **👷 now routes to CI instead of Added.** `^👷` was listed in both the Features and the CI parser block; first match wins, so CI work was filed as a feature while the CI section only ever collected 💚. 10 entries change section as a result.

Commit preprocessors and the version-bump regexes are untouched (👷 appears in neither `custom_minor_increment_regex` nor `custom_major_increment_regex`). The emoji still sits at the start of the commit message, so parsers and bump rules match exactly as before — the strip happens at render time only.

## Verification

`git-cliff` 2.13.1 was run over the complete history of all eight repos sharing this template, with the pre-change and post-change configs, and every rendered entry compared as a multiset. In every repo: each entry in an emoji-headed group is its pre-change text minus exactly one prefix emoji, `Other` is byte-identical to pre-change, and the entry count is unchanged.

| repo | commits | entries |
|---|---|---|
| rust-analyzer-mcp | 132 | 111 |
| pixel8 | 502 | 408 |
| zbus | 6364 | 4987 |
| gimoji | 562 | 206 |
| busd | 637 | 296 |
| zlink | 1104 | 910 |
| zgvariant | 37 | 26 |
| zcheapstr | 21 | 10 |

Across all ~9,000 commits, exactly one subject carries two emoji (in zbus); per the contract its second emoji is title text and is kept. Nothing in this repo moves.

## Note

release-plz only prepends to `CHANGELOG.md`, so existing entries keep the old per-entry emoji. The new style starts with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016iaTmaTUYJK5yuq86tGSuJ